### PR TITLE
Bug - Lookup method visibility 

### DIFF
--- a/lib/i18n/debug.rb
+++ b/lib/i18n/debug.rb
@@ -28,6 +28,8 @@ module I18n
     end
 
     module Hook
+      protected
+
       def lookup(*args)
         super.tap do |result|
           options = args.last.is_a?(Hash) ? args.pop : {}

--- a/test/test_i18n_debug.rb
+++ b/test/test_i18n_debug.rb
@@ -19,6 +19,10 @@ class TestI18nDebug < Minitest::Test
     end
   end
 
+  def test_does_not_alter_default_i18n_lookup_method_visibility
+    assert I18n.backend.class.protected_method_defined?(:lookup)
+  end
+
   def test_logger_invoked
     assert_output(/en\.foo\.bar => "baz"/) do
       I18n.t('foo.bar')


### PR DESCRIPTION
Corrects visibility of I18n backend `#lookup` method

Discovered this in surprising failure situation where gem was included in `group :development, :test`, but not in `:production` -> custom I18n logic call to `#lookup` started to fail with visibility errors.

Signed-off-by: Aleksandrs Ļedovskis <aleksandrs@ledovskis.lv>