### PR TITLE
fix: rails logger maybe nil

### DIFF
--- a/lib/i18n/debug.rb
+++ b/lib/i18n/debug.rb
@@ -13,7 +13,7 @@ module I18n
 
       def logger
         @logger ||=
-          if defined?(::Rails) and ::Rails.respond_to?(:logger)
+          if defined?(::Rails) && ::Rails.respond_to?(:logger) && ::Rails.logger.present?
             ::Rails.logger
           else
             require 'logger'


### PR DESCRIPTION
Had the situation that i'm running in a Rails environment, but Rails.logger was null, resulting in ```…/gems/i18n-debug-1.2.0/lib/i18n/debug.rb:17:in `logger': undefined method `debug' for nil:NilClass```

